### PR TITLE
Prototype with event dispatcher

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
     listbox
     #listbox="listbox"
     [wrap]="wrap"
-    [vertical]="vertical"
+    [orientation]="vertical ? 'vertical' : 'horizontal'"
     [rovingFocus]="rovingFocus"
     [followFocus]="followFocus"
     [skipDisabled]="skipDisabled"
@@ -20,14 +20,14 @@
     </li>
     }
   </ul>
-  @if (listbox.composable.typeaheadManager.query()) {
-    <span class="typeahead">{{ listbox.composable.typeaheadManager.query() | titlecase }}</span>
+  @if (listbox.state.query()) {
+  <span class="typeahead">{{ listbox.state.query() | titlecase }}</span>
   }
 </div>
 
 <div class="hud">
   <div>
-    <span>Typeahead: {{ listbox.composable.typeaheadManager.query() }}</span>
+    <span>Typeahead: {{ listbox.state.query() }}</span>
   </div>
   <div>
     <label for="wrap-input">Wrap: </label>
@@ -51,24 +51,42 @@
 
   <div>
     <label for="skip-disabled-input">Skip Disabled Options: </label>
-    <input id="skip-disabled-input" type="checkbox" [(ngModel)]="skipDisabled" />
+    <input
+      id="skip-disabled-input"
+      type="checkbox"
+      [(ngModel)]="skipDisabled"
+    />
   </div>
 
   <div>
     <label for="multiselectable-input">Multiselectable: </label>
-    <input id="multiselectable-input" type="checkbox" [(ngModel)]="multiselectable" />
+    <input
+      id="multiselectable-input"
+      type="checkbox"
+      [(ngModel)]="multiselectable"
+    />
   </div>
 
   <div>
     <label for="current-index-input">Current Index: </label>
-    <input id="current-index-input" type="number" min="0" [max]="states.length - 1" [(ngModel)]="currentIndex" />
+    <input
+      id="current-index-input"
+      type="number"
+      min="0"
+      [max]="states.length - 1"
+      [(ngModel)]="currentIndex"
+    />
   </div>
 
   <div>
     <label for="selected-indices-input">Selected Indices: </label>
-    <select id="selected-indices-input" [(ngModel)]="selectedIndices" [multiple]="multiselectable">
+    <select
+      id="selected-indices-input"
+      [(ngModel)]="selectedIndices"
+      [multiple]="multiselectable"
+    >
       @for (state of states; track state) {
-      <option [value]="$index">{{state}}</option>
+      <option [value]="$index">{{ state }}</option>
       }
     </select>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,16 @@
-import { Component, inject } from '@angular/core';
-import { Listbox } from './ui-primitives-2/listbox.directive';
-import { Option } from './ui-primitives-2/option.directive';
-import { StatesService } from './states.service';
-import { FormsModule } from '@angular/forms';
 import { TitleCasePipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { StatesService } from './states.service';
+import { Listbox } from './ui-primitives-dispatcher/listbox.directive';
+import { Option } from './ui-primitives-dispatcher/option.directive';
 
 @Component({
   selector: 'app-root',
   standalone: true,
   imports: [FormsModule, Listbox, Option, TitleCasePipe],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css'
+  styleUrl: './app.component.css',
 })
 export class AppComponent {
   title = 'ui-primitives';

--- a/src/app/composables-dispatcher/event-dispatcher.ts
+++ b/src/app/composables-dispatcher/event-dispatcher.ts
@@ -1,0 +1,18 @@
+export class EventDispatcher<T extends Event> {
+  private readonly listeners = new Set<(event: T) => void | boolean>();
+
+  listen(listener: (event: T) => void | boolean) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  dispatch(event: T) {
+    for (const listener of this.listeners) {
+      if (listener(event)) {
+        break;
+      }
+    }
+  }
+}

--- a/src/app/composables-dispatcher/focus/focus-state.ts
+++ b/src/app/composables-dispatcher/focus/focus-state.ts
@@ -1,0 +1,34 @@
+import { computed, Signal, WritableSignal } from '@angular/core';
+
+interface Item {
+  readonly id: Signal<string>;
+}
+
+export interface FocusInputs<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly rovingFocus: Signal<boolean>;
+  readonly currentIndex: WritableSignal<number>;
+}
+
+export class FocusState<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly rovingFocus: Signal<boolean>;
+  readonly currentIndex: WritableSignal<number>;
+
+  readonly focusIndex = computed(() =>
+    this.rovingFocus() ? this.currentIndex() : -1
+  );
+  readonly activeIndex = computed(() =>
+    this.rovingFocus() ? -1 : this.currentIndex()
+  );
+  readonly focusItem = computed(() => this.items()[this.focusIndex()]);
+  readonly activeItem = computed(() => this.items()[this.activeIndex()]);
+  readonly tabindex = computed(() => (this.rovingFocus() ? -1 : 0));
+  readonly activedescendant = computed(() => this.activeItem()?.id() ?? null);
+
+  constructor(inputs: FocusInputs<T>) {
+    this.items = inputs.items;
+    this.rovingFocus = inputs.rovingFocus;
+    this.currentIndex = inputs.currentIndex;
+  }
+}

--- a/src/app/composables-dispatcher/listbox/listbox-controller.ts
+++ b/src/app/composables-dispatcher/listbox/listbox-controller.ts
@@ -1,0 +1,14 @@
+import { type ListboxState } from './listbox-state';
+
+export class ListboxController<T extends ListboxState<any>> {
+  constructor(private readonly state: T) {}
+
+  handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowUp') {
+      console.log('Up arrow disabled!');
+      event.preventDefault();
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/app/composables-dispatcher/listbox/listbox-state.ts
+++ b/src/app/composables-dispatcher/listbox/listbox-state.ts
@@ -1,0 +1,62 @@
+import { Signal } from '@angular/core';
+import { FocusInputs, FocusState } from '../focus/focus-state';
+import {
+  NavigationInputs,
+  NavigationState,
+} from '../navigation/navigation-state';
+import { OptionState } from '../option/option-state';
+import { SelectionInputs, SelectionState } from '../selection/selection-state';
+import { TypeAheadInputs, TypeaheadState } from '../typeahead/typeahead-state';
+import { ListboxController } from './listbox-controller';
+
+export type ListboxInputs<T extends OptionState> = NavigationInputs<T> &
+  TypeAheadInputs<T> &
+  SelectionInputs<T> &
+  FocusInputs<T>;
+
+export class ListboxState<T extends OptionState> {
+  readonly orientation: Signal<'horizontal' | 'vertical'>;
+  readonly tabindex: Signal<number>;
+  readonly multiselectable: Signal<boolean>;
+  readonly activedescendant: Signal<string>;
+  readonly items: Signal<T[]>;
+  readonly focusIndex: Signal<number>;
+  readonly activeIndex: Signal<number>;
+  readonly selectedIndices: Signal<number[]>;
+  readonly query: Signal<string>;
+
+  private readonly focusManager: FocusState<T>;
+  private readonly typeaheadManager: TypeaheadState<T>;
+  private readonly selectionManager: SelectionState<T>;
+  private readonly navigationManager: NavigationState<T>;
+
+  private controller?: ListboxController<ListboxState<T>>;
+
+  constructor(inputs: ListboxInputs<T>) {
+    inputs.keydownEvents.listen((event) =>
+      this.getController().handleKeydown(event)
+    );
+
+    this.focusManager = new FocusState(inputs);
+    this.typeaheadManager = new TypeaheadState(inputs);
+    this.selectionManager = new SelectionState(inputs);
+    this.navigationManager = new NavigationState(inputs);
+
+    this.orientation = inputs.orientation;
+    this.tabindex = this.focusManager.tabindex;
+    this.multiselectable = inputs.multiselectable;
+    this.activedescendant = this.focusManager.activedescendant;
+    this.items = inputs.items;
+    this.focusIndex = this.focusManager.focusIndex; // TODO: shouldn't need 3 copies of active index
+    this.activeIndex = this.focusManager.activeIndex;
+    this.selectedIndices = this.selectionManager.selectedIndices;
+    this.query = this.typeaheadManager.query;
+  }
+
+  getController() {
+    // TODO: dynamic import
+    const controller = this.controller ?? new ListboxController(this);
+    this.controller = controller;
+    return controller;
+  }
+}

--- a/src/app/composables-dispatcher/navigation/navigation-controller.ts
+++ b/src/app/composables-dispatcher/navigation/navigation-controller.ts
@@ -1,0 +1,91 @@
+import { computed, signal } from '@angular/core';
+import { type NavigationState } from './navigation-state';
+
+export class NavigationController<T extends NavigationState<any>> {
+  constructor(private readonly state: T) {}
+
+  handlePointerdown(event: PointerEvent) {
+    if (event.target instanceof HTMLElement) {
+      const li = event.target.closest('li');
+
+      if (li) {
+        const index = this.state.items().findIndex((i) => i.id() === li.id);
+        this.navigateTo(index);
+      }
+    }
+  }
+
+  handleKeydown(event: KeyboardEvent) {
+    const upOrLeft =
+      this.state.orientation() === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+    const downOrRight =
+      this.state.orientation() === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+
+    switch (event.key) {
+      case downOrRight:
+        this.navigateNext();
+        break;
+      case upOrLeft:
+        this.navigatePrev();
+        break;
+      case 'Home':
+        this.navigateFirst();
+        break;
+      case 'End':
+        this.navigateLast();
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+  }
+
+  navigateTo(index: number): void {
+    if (!this.state.items()[index]?.disabled()) {
+      this.state.currentIndex.set(index);
+    }
+  }
+
+  navigatePrev() {
+    this.navigate(this.getPrevIndex);
+  }
+
+  navigateNext() {
+    this.navigate(this.getNextIndex);
+  }
+
+  navigateFirst() {
+    this.state.currentIndex.set(this.state.firstIndex());
+  }
+
+  navigateLast() {
+    this.state.currentIndex.set(this.state.lastIndex());
+  }
+
+  getPrevIndex = (index: number) => {
+    const prevIndex =
+      this.state.wrap() && index === 0 ? this.state.lastIndex() : index - 1;
+    return Math.max(prevIndex, this.state.firstIndex());
+  };
+
+  getNextIndex = (index: number) => {
+    const nextIndex =
+      this.state.wrap() && index === this.state.lastIndex() ? 0 : index + 1;
+    return Math.min(nextIndex, this.state.lastIndex());
+  };
+
+  private navigate(navigateFn: (i: number) => number): void {
+    const index = signal(this.state.currentIndex());
+    const isLoop = computed(() => index() === this.state.currentIndex());
+    const shouldSkip = computed(
+      () => this.state.skipDisabled() && this.state.items()[index()]?.disabled()
+    );
+
+    do {
+      index.update(navigateFn);
+    } while (shouldSkip() && !isLoop());
+
+    this.state.currentIndex.set(index());
+  }
+}

--- a/src/app/composables-dispatcher/navigation/navigation-state.ts
+++ b/src/app/composables-dispatcher/navigation/navigation-state.ts
@@ -1,0 +1,74 @@
+import { computed, Signal, WritableSignal } from '@angular/core';
+import { EventDispatcher } from '../event-dispatcher';
+import { NavigationController } from './navigation-controller';
+
+interface Item {
+  readonly disabled: Signal<boolean>;
+}
+
+export interface NavigationInputs<T extends Item> {
+  readonly wrap: Signal<boolean>;
+  readonly items: Signal<T[]>;
+  readonly skipDisabled: Signal<boolean>;
+  readonly currentIndex: WritableSignal<number>; // TODO: should we just require `Signal` and created a `linkedSignal` on it?
+  readonly orientation: Signal<'horizontal' | 'vertical'>;
+  readonly keydownEvents: EventDispatcher<KeyboardEvent>;
+  readonly pointerdownEvents: EventDispatcher<PointerEvent>;
+}
+
+export class NavigationState<T extends Item> {
+  readonly wrap: Signal<boolean>;
+  readonly items: Signal<T[]>;
+  readonly skipDisabled: Signal<boolean>;
+  readonly currentIndex: WritableSignal<number>;
+  readonly orientation: Signal<'horizontal' | 'vertical'>;
+
+  private controller?: NavigationController<NavigationState<T>>;
+
+  readonly currentItem = computed(() => this.items()[this.currentIndex()]);
+
+  readonly firstIndex = computed(() => {
+    if (!this.skipDisabled()) {
+      return 0;
+    }
+    return this.items().findIndex((i) => !i.disabled()) ?? -1;
+  });
+
+  readonly lastIndex = computed(() => {
+    const items = this.items();
+
+    if (!this.skipDisabled()) {
+      return items.length - 1;
+    }
+
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (!items[i].disabled()) {
+        return i;
+      }
+    }
+
+    return -1;
+  });
+
+  constructor(inputs: NavigationInputs<T>) {
+    inputs.keydownEvents.listen((event) =>
+      this.getController().handleKeydown(event)
+    );
+    inputs.pointerdownEvents.listen((event) =>
+      this.getController().handlePointerdown(event)
+    );
+
+    this.wrap = inputs.wrap;
+    this.items = inputs.items;
+    this.skipDisabled = inputs.skipDisabled;
+    this.currentIndex = inputs.currentIndex;
+    this.orientation = inputs.orientation;
+  }
+
+  getController() {
+    // TODO: dynamic import
+    const controller = this.controller ?? new NavigationController(this);
+    this.controller = controller;
+    return controller;
+  }
+}

--- a/src/app/composables-dispatcher/option/option-state.ts
+++ b/src/app/composables-dispatcher/option/option-state.ts
@@ -1,0 +1,38 @@
+import { computed, Signal } from '@angular/core';
+import { ListboxState } from '../listbox/listbox-state';
+
+export interface OptionInputs {
+  readonly disabled: Signal<boolean>;
+  readonly searchTerm: Signal<string>;
+  readonly listbox: ListboxState<OptionState>;
+}
+
+let counter = -1;
+
+export class OptionState {
+  readonly disabled: Signal<boolean>;
+  readonly searchTerm: Signal<string>;
+  readonly listbox: ListboxState<OptionState>;
+
+  readonly id = computed(() => `${counter++}`);
+  readonly setsize = computed(() => this.listbox.items().length);
+  readonly posinset = computed(() =>
+    this.listbox.items().findIndex((item) => item.id() === this.id())
+  );
+  readonly focused = computed(
+    () => this.listbox.focusIndex() === this.posinset()
+  );
+  readonly active = computed(
+    () => this.listbox.activeIndex() === this.posinset()
+  );
+  readonly selected = computed(() =>
+    this.listbox.selectedIndices().includes(this.posinset())
+  );
+  readonly tabindex = computed(() => (this.focused() ? 0 : -1));
+
+  constructor(inputs: OptionInputs) {
+    this.listbox = inputs.listbox;
+    this.disabled = inputs.disabled;
+    this.searchTerm = inputs.searchTerm;
+  }
+}

--- a/src/app/composables-dispatcher/selection/selection-controller.ts
+++ b/src/app/composables-dispatcher/selection/selection-controller.ts
@@ -1,0 +1,135 @@
+import { type SelectionState } from './selection-state';
+
+export class SelectionController<T extends SelectionState<any>> {
+  constructor(private readonly state: T) {}
+
+  handlePointerdown(event: PointerEvent) {
+    if (event.target instanceof HTMLElement) {
+      const li = event.target.closest('li');
+
+      if (li) {
+        const index = this.state.items().findIndex((i) => i.id() === li.id);
+        this.state.multiselectable() ? this.toggle() : this.select();
+      }
+    }
+  }
+
+  handleKeydown(event: KeyboardEvent) {
+    if (this.state.multiselectable()) {
+      this.handleKeydownForMultiselection(event);
+    } else {
+      this.handleKeydownForSingleSelection(event);
+    }
+  }
+
+  private handleKeydownForMultiselection(event: KeyboardEvent) {
+    const upOrLeft =
+      this.state.orientation() === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+    const downOrRight =
+      this.state.orientation() === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+
+    if (event.ctrlKey) {
+      if (event.key === 'a') {
+        this.toggleAll();
+        event.preventDefault();
+        return;
+      }
+    }
+
+    if (event.ctrlKey && event.shiftKey) {
+      if (event.key === 'Home' || event.key === 'End') {
+        this.selectFromAnchor();
+        event.preventDefault();
+        return;
+      }
+    }
+
+    if (event.shiftKey) {
+      if (event.key === ' ') {
+        this.selectFromAnchor();
+        event.preventDefault();
+        return;
+      } else if (event.key === downOrRight || event.key === upOrLeft) {
+        this.toggle();
+        event.preventDefault();
+        return;
+      }
+    }
+
+    if (event.key === ' ') {
+      event.preventDefault();
+      this.toggle();
+    }
+  }
+
+  private handleKeydownForSingleSelection(event: KeyboardEvent) {
+    // TODO: shouldn't this just be part of the computed()?
+    if (this.state.followFocus()) {
+      this.select();
+      return;
+    }
+
+    switch (event.key) {
+      case ' ':
+        this.toggle();
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+  }
+
+  select() {
+    this.state.anchorIndex.set(this.state.currentIndex());
+    if (this.state.multiselectable()) {
+      this.state.selectedIndices.update((arr) =>
+        arr.concat([this.state.currentIndex()])
+      );
+    } else {
+      this.state.selectedIndices.set([this.state.currentIndex()]);
+    }
+  }
+
+  deselect() {
+    this.state.selectedIndices.update((arr) =>
+      arr.filter((i) => i !== this.state.currentIndex())
+    );
+  }
+
+  toggle() {
+    this.state.selectedIndices().includes(this.state.currentIndex())
+      ? this.deselect()
+      : this.select();
+  }
+
+  selectAll() {
+    this.state.selectedIndices.set(this.state.items().map((_, i) => i));
+  }
+
+  deselectAll() {
+    this.state.selectedIndices.set([]);
+  }
+
+  toggleAll() {
+    if (this.state.selectedIndices().length === this.state.items().length) {
+      this.deselectAll();
+    } else {
+      this.selectAll();
+    }
+  }
+
+  selectFromAnchor() {
+    if (this.state.anchorIndex() === -1) {
+      return;
+    }
+
+    const upper = Math.max(this.state.currentIndex(), this.state.anchorIndex());
+    const lower = Math.min(this.state.currentIndex(), this.state.anchorIndex());
+    const range = Array.from(
+      { length: upper - lower + 1 },
+      (_, i) => lower + i
+    );
+    this.state.selectedIndices.update((arr) => arr.concat(range));
+  }
+}

--- a/src/app/composables-dispatcher/selection/selection-state.ts
+++ b/src/app/composables-dispatcher/selection/selection-state.ts
@@ -1,0 +1,58 @@
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { EventDispatcher } from '../event-dispatcher';
+import { SelectionController } from './selection-controller';
+
+interface Item {
+  readonly disabled: Signal<boolean>;
+  readonly selected: Signal<boolean>;
+}
+
+export interface SelectionInputs<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly followFocus: Signal<boolean>;
+  readonly multiselectable: Signal<boolean>;
+  readonly orientation: Signal<'horizontal' | 'vertical'>;
+  readonly currentIndex: WritableSignal<number>;
+  readonly selectedIndices: WritableSignal<number[]>;
+  readonly keydownEvents: EventDispatcher<KeyboardEvent>;
+  readonly pointerdownEvents: EventDispatcher<PointerEvent>;
+}
+
+export class SelectionState<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly followFocus: Signal<boolean>;
+  readonly multiselectable: Signal<boolean>;
+  readonly orientation: Signal<'horizontal' | 'vertical'>;
+  readonly currentIndex: WritableSignal<number>;
+  readonly selectedIndices: WritableSignal<number[]>;
+
+  private controller?: SelectionController<SelectionState<T>>;
+
+  readonly anchorIndex = signal(-1);
+  readonly selectedItems = computed(() =>
+    this.selectedIndices().map((i) => this.items()[i]!)
+  );
+
+  constructor(inputs: SelectionInputs<T>) {
+    inputs.keydownEvents.listen((event) =>
+      this.getController().handleKeydown(event)
+    );
+    inputs.pointerdownEvents.listen((event) =>
+      this.getController().handlePointerdown(event)
+    );
+
+    this.items = inputs.items;
+    this.followFocus = inputs.followFocus;
+    this.multiselectable = inputs.multiselectable;
+    this.orientation = inputs.orientation;
+    this.currentIndex = inputs.currentIndex;
+    this.selectedIndices = inputs.selectedIndices;
+  }
+
+  getController() {
+    // TODO: dynamic import
+    const controller = this.controller ?? new SelectionController(this);
+    this.controller = controller;
+    return controller;
+  }
+}

--- a/src/app/composables-dispatcher/typeahead/typeahead-controller.ts
+++ b/src/app/composables-dispatcher/typeahead/typeahead-controller.ts
@@ -1,0 +1,78 @@
+import { type TypeaheadState } from './typeahead-state';
+
+export class TypeaheadController<T extends TypeaheadState<any>> {
+  private timeout: any;
+
+  constructor(private readonly state: T) {}
+
+  handleKeydown(event: KeyboardEvent) {
+    this.search(event.key);
+  }
+
+  search(char: string) {
+    if (!this.isValid(char)) {
+      return;
+    }
+
+    clearTimeout(this.timeout);
+
+    this.state.query.update((str) => str + char.toLowerCase());
+    const startIndex =
+      this.state.query().length === 1
+        ? this.state.currentIndex() + 1
+        : this.state.currentIndex();
+    const index = findIndexFrom(
+      this.state.items(),
+      (i) => i.searchTerm().toLowerCase().startsWith(this.state.query()),
+      startIndex
+    );
+
+    if (index !== -1) {
+      this.state.currentIndex.set(index);
+    }
+
+    this.timeout = setTimeout(() => {
+      this.state.query.set('');
+    }, this.state.delay());
+  }
+
+  private isValid(char: string): boolean {
+    if (char.length !== 1) {
+      return false;
+    }
+
+    if (this.state.query().length > 0 && char === ' ') {
+      return true;
+    }
+
+    if (/[a-zA-z0-9]/.test(char)) {
+      return true;
+    }
+
+    if (this.state.matcher().test(char)) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+function findIndexFrom<T>(
+  array: T[],
+  predicate: (value: T, index: number, obj: T[]) => unknown,
+  startIndex = 0
+): number {
+  for (let i = startIndex; i < array.length; i++) {
+    if (predicate(array[i], i, array)) {
+      return i;
+    }
+  }
+
+  for (let i = 0; i < startIndex; i++) {
+    if (predicate(array[i], i, array)) {
+      return i;
+    }
+  }
+
+  return -1;
+}

--- a/src/app/composables-dispatcher/typeahead/typeahead-state.ts
+++ b/src/app/composables-dispatcher/typeahead/typeahead-state.ts
@@ -1,0 +1,43 @@
+import { Signal, signal, WritableSignal } from '@angular/core';
+import { EventDispatcher } from '../event-dispatcher';
+import { TypeaheadController } from './typeahead-controller';
+
+export interface Item {
+  readonly searchTerm: Signal<string>;
+}
+
+export interface TypeAheadInputs<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly delay: Signal<number>;
+  readonly matcher: Signal<RegExp>;
+  readonly currentIndex: WritableSignal<number>;
+  readonly keydownEvents: EventDispatcher<KeyboardEvent>;
+}
+
+export class TypeaheadState<T extends Item> {
+  readonly items: Signal<T[]>;
+  readonly delay: Signal<number>;
+  readonly matcher: Signal<RegExp>;
+  readonly currentIndex: WritableSignal<number>;
+  readonly query = signal('');
+
+  private controller?: TypeaheadController<TypeaheadState<T>>;
+
+  constructor(inputs: TypeAheadInputs<T>) {
+    inputs.keydownEvents.listen((event) =>
+      this.getController().handleKeydown(event)
+    );
+
+    this.items = inputs.items;
+    this.delay = inputs.delay;
+    this.matcher = inputs.matcher;
+    this.currentIndex = inputs.currentIndex;
+  }
+
+  getController() {
+    // TODO: dynamic import
+    const controller = this.controller ?? new TypeaheadController(this);
+    this.controller = controller;
+    return controller;
+  }
+}

--- a/src/app/ui-primitives-dispatcher/listbox.directive.ts
+++ b/src/app/ui-primitives-dispatcher/listbox.directive.ts
@@ -1,0 +1,51 @@
+import { computed, contentChildren, Directive, model } from '@angular/core';
+import { EventDispatcher } from '../composables-dispatcher/event-dispatcher';
+import { ListboxState } from '../composables-dispatcher/listbox/listbox-state';
+import { OptionState } from '../composables-dispatcher/option/option-state';
+import { Option } from './option.directive';
+
+@Directive({
+  selector: '[listbox]',
+  exportAs: 'listbox',
+  standalone: true,
+  host: {
+    role: 'listbox',
+    '[attr.tabindex]': 'state.tabindex()',
+    '[attr.aria-orientation]': 'state.orientation()',
+    '[attr.aria-multiselectable]': 'state.multiselectable()',
+    '[attr.aria-activedescendant]': 'state.activedescendant()',
+    '(keydown)': 'keydownEvents.dispatch($event)',
+    '(pointerdown)': 'pointerdownEvents.dispatch($event)',
+  },
+})
+export class Listbox {
+  wrap = model.required<boolean>();
+  orientation = model.required<'horizontal' | 'vertical'>();
+  followFocus = model.required<boolean>();
+  rovingFocus = model.required<boolean>();
+  skipDisabled = model.required<boolean>();
+  multiselectable = model.required<boolean>();
+  keydownEvents = new EventDispatcher<KeyboardEvent>();
+  pointerdownEvents = new EventDispatcher<PointerEvent>();
+
+  // This is a demonstration of how we can rename properties
+  // if their meaning becomes unclear after being forwarded.
+
+  typeaheadDelay = model.required<number>();
+  typeaheadMatcher = model.required<RegExp>();
+
+  delay = this.typeaheadDelay;
+  matcher = this.typeaheadMatcher;
+
+  currentIndex = model.required<number>();
+  selectedIndices = model.required<number[]>();
+
+  children = contentChildren(Option);
+  items = computed(() => this.children().map((c) => c.state));
+
+  state: ListboxState<OptionState>;
+
+  constructor() {
+    this.state = new ListboxState(this);
+  }
+}

--- a/src/app/ui-primitives-dispatcher/option.directive.ts
+++ b/src/app/ui-primitives-dispatcher/option.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, effect, ElementRef, inject, model } from '@angular/core';
+import { OptionState } from '../composables-dispatcher/option/option-state';
+import { Listbox } from './listbox.directive';
+
+@Directive({
+  selector: '[option]',
+  exportAs: 'option',
+  standalone: true,
+  host: {
+    role: 'option',
+    '[attr.id]': 'state.id()',
+    '[attr.tabindex]': 'state.tabindex()',
+    '[attr.aria-setsize]': 'state.setsize()',
+    '[attr.aria-posinset]': 'state.posinset()',
+    '[attr.aria-selected]': 'state.selected()',
+    '[attr.aria-disabled]': 'state.disabled()',
+    '[class.active]': 'state.active()',
+    '[class.focused]': 'state.focused()',
+  },
+})
+export class Option {
+  searchTerm = model.required<string>();
+  disabled = model<boolean>(false);
+  listbox = inject(Listbox).state;
+
+  hostEl = inject(ElementRef).nativeElement;
+  state: OptionState;
+
+  constructor() {
+    this.state = new OptionState(this);
+    effect(() => {
+      if (this.state.focused()) {
+        this.hostEl.focus();
+      }
+      if (this.state.active()) {
+        this.hostEl.scrollIntoView({
+          block: 'nearest',
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
Prototype using event dispatcher, which:
- simplifies splitting event handling logic across different composables
- makes it harder to forget to update wrapper directives when adding a new event to a composable
- allows higher level composable to tell child composables that the event has already been handled

Also includes a suggestion for splitting the handler logic for potential deferring. This part isn't really dependent on using the dispatcher, could do a similar thing with the plain `handleXXX` functions